### PR TITLE
Added APPMENUS_DIR to allow appmenus to be placed elsewhere

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -81,19 +81,28 @@ fi
 
 if [ "${VERBOSE}" -ge 2 -o "${DEBUG}" == "1" ]; then
     chroot() {
+        # Display `chroot` or `systemd-nspawn` in blue ONLY if VERBOSE >= 2
+        # or DEBUG == "1"
         local retval
         true ${blue}
+
+        # Need to capture exit code after running chroot or systemd-nspawn
+        # so it will be available as a return value
         if [ "${SYSTEMD_NSPAWN_ENABLE}"  == "1" ]; then
-            systemd-nspawn $systemd_bind -D "${INSTALLDIR}" -M "${DIST}" "$@" && { retval=$?; true; } || { retval=$?; true; }
+            systemd-nspawn $systemd_bind -D "${INSTALLDIR}" -M "${DIST}" ${1+"$@"} && { retval=$?; true; } || { retval=$?; true; }
         else
-            /usr/sbin/chroot "${INSTALLDIR}" "$@" && { retval=$?; true; } || { retval=$?; true; }
+            /usr/sbin/chroot "${INSTALLDIR}" ${1+"$@"} && { retval=$?; true; } || { retval=$?; true; }
         fi
         true ${reset}
         return $retval
     }
 else
     chroot() {
-        /usr/sbin/chroot "${INSTALLDIR}" "$@"
+        if [ "${SYSTEMD_NSPAWN_ENABLE}"  == "1" ]; then
+            systemd-nspawn $systemd_bind -D "${INSTALLDIR}" -M "${DIST}" ${1+"$@"}
+        else
+            /usr/sbin/chroot "${INSTALLDIR}" ${1+"$@"}
+        fi
     }
 fi
 

--- a/qubeize_image
+++ b/qubeize_image
@@ -77,13 +77,14 @@ export INSTALLDIR=mnt
 # Create App Menus
 # ------------------------------------------------------------------------------
 echo "--> Choosing appmenus whitelists..."
+_appmenus_dir="${APPMENUS_DIR-${SCRIPTSDIR}}"
 rm -f appmenus
-if [ -d "${SCRIPTSDIR}/appmenus_${DIST}_${TEMPLATE_FLAVOR}" ]; then
-    ln -s "${SCRIPTSDIR}/appmenus_${DIST}_${TEMPLATE_FLAVOR}" appmenus
-elif [ -d "${SCRIPTSDIR}/appmenus_$DIST" ]; then
-    ln -s "${SCRIPTSDIR}/appmenus_$DIST" appmenus
-elif [ -d "${SCRIPTSDIR}/appmenus" ]; then
-    ln -s "${SCRIPTSDIR}/appmenus" appmenus
+if [ -d "${_appmenus_dir}/appmenus_${DIST}_${TEMPLATE_FLAVOR}" ]; then
+    ln -s "${_appmenus_dir}/appmenus_${DIST}_${TEMPLATE_FLAVOR}" appmenus
+elif [ -d "${_appmenus_dir}/appmenus_$DIST" ]; then
+    ln -s "${_appmenus_dir}/appmenus_$DIST" appmenus
+elif [ -d "${_appmenus_dir}/appmenus" ]; then
+    ln -s "${_appmenus_dir}/appmenus" appmenus
 else
     ln -s "appmenus_generic" appmenus
 fi


### PR DESCRIPTION
If the `APPMENUS_DIR` `ENV` var is set it will be used to locate the `appmenus` otherwise the default behaviour will result back to the `$SCRIPTSDIR`
```
_appmenus_dir="${APPMENUS_DIR-${SCRIPTSDIR}}"
```

Added some comments to chroot function in `functions.sh` and included the missing `systemd-nspawn` is it was only able to be used if `VERBOSE >= 2` or `DEBUG == 1`