### PR TITLE
Fix renaming  templates that have a flavor and options such as gnome

### DIFF
--- a/functions-name.sh
+++ b/functions-name.sh
@@ -86,7 +86,7 @@ templateName() {
     if [ -n "${1}" ] || [ "X${TEMPLATE_OPTIONS}" == "X" ]; then
         local template_options=
     else
-        local template_options=$(printf '%s' ${TEMPLATE_OPTIONS[@]/#/+})
+        local template_options=$(printf '+%s' ${TEMPLATE_OPTIONS[@]})
     fi
 
     local template_name="$(templateFlavorPrefix ${template_flavor})${template_flavor}${template_options}"


### PR DESCRIPTION
jessie+whonix-workstation+gnome+standard was not converting name using
TEMPLATE_LABEL since the options we getting mangled (+gnomestandard)
where thye should have returned (+gnome+standard)