### PR TITLE
fixed 'verbosity disabling bug'

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -12,21 +12,6 @@ DEBUG=${DEBUG:-0}
 # Global functions
 ################################################################################
 # ------------------------------------------------------------------------------
-# Set xtrace verbose mode (-x or)
-# ------------------------------------------------------------------------------
-XTRACE=
-function setVerboseMode() {
-    # Cache xtrace current status so it can be restored on exit
-    [[ ${-/x} != $- ]] && XTRACE=0 || XTRACE=1
-
-    if [ "${VERBOSE}" -ge 2 -o "${DEBUG}" -ge 2 ]; then
-        set -x
-    else
-        set +x
-    fi
-}
-
-# ------------------------------------------------------------------------------
 # Define colors
 # ------------------------------------------------------------------------------
 colors() {
@@ -107,22 +92,6 @@ else
 fi
 
 # ------------------------------------------------------------------------------
-# Return xtrace's current mode
-# 0 is enables (-x); 1 is disables (+x)
-# ------------------------------------------------------------------------------
-getXtrace() {
-    [[ ${-/x} != $- ]] && echo 0 || echo 1
-}
-
-# ------------------------------------------------------------------------------
-# Return xtrace to desired state
-# 0 is enables (-x); 1 is disables (+x)
-# ------------------------------------------------------------------------------
-setXtrace() {
-    [[ "${1}" -eq 0 ]] && set -x || set +x
-}
-
-# ------------------------------------------------------------------------------
 # Display messages in color
 # ------------------------------------------------------------------------------
 # Only output text under certain conditions
@@ -170,7 +139,7 @@ setArrayAsGlobal() {
     local code=$(declare -p "$array")
     local replaced="${code/$array/$export_as}"
     eval ${replaced/declare -/declare -g}
-} 
+}
 
 
 # ------------------------------------------------------------------------------
@@ -224,12 +193,12 @@ templateDir() {
     local template_flavor=${1-${TEMPLATE_FLAVOR}}
 
     # If TEMPLATE_FLAVOR_DIR is not already an array, make it one
-    if ! [[ "$(declare -p TEMPLATE_FLAVOR_DIR 2>/dev/null)" =~ ^declare\ -a.* ]] ; then 
+    if ! [[ "$(declare -p TEMPLATE_FLAVOR_DIR 2>/dev/null)" =~ ^declare\ -a.* ]] ; then
         TEMPLATE_FLAVOR_DIR=( ${TEMPLATE_FLAVOR_DIR} )
     fi
 
     for element in "${TEMPLATE_FLAVOR_DIR[@]}"
-    do 
+    do
         # (wheezy+whonix-gateway / wheezy+whonix-gateway+gnome[+++] / wheezy+gnome )
         if [ "${element%:*}" == "$(templateName ${template_flavor})" ]; then
             eval echo -e "${element#*:}"
@@ -282,7 +251,7 @@ templateFile() {
             exists "${SCRIPTSDIR}/${path_parts[base]}_${suffix}${path_parts[dotext]}" || true
         else
             exists "${SCRIPTSDIR}/${path_parts[base]}${path_parts[dotext]}" || true
-        fi    
+        fi
         return
     fi
 
@@ -357,7 +326,7 @@ callTemplateFunction() {
     local calling_arg="$2"
     local functionExec="$3"
     local template_flavor="${TEMPLATE_FLAVOR}"
- 
+
     ${functionExec} "${calling_script}" \
                     "${calling_arg}" \
                     "${template_flavor}"
@@ -389,7 +358,7 @@ callTemplateFunction() {
 
 # ------------------------------------------------------------------------------
 # Will return all files that match pattern of suffix
-# Example: 
+# Example:
 #   filename = packages.list
 #   suffix = ${DIST} (wheezy)
 #
@@ -424,8 +393,8 @@ getFileLocations() {
 # Executes any additional optional configuration steps if the configuration
 # scripts exist
 #
-# Will find all scripts with 
-# Example: 
+# Will find all scripts with
+# Example:
 #   filename = 04_install_qubes.sh
 #   suffix = post
 #
@@ -447,7 +416,7 @@ buildStep() {
         if [ -e "${script}" ]; then
             # Test module expects raw  output back only used to asser test results
             if [[ -n ${TEST} ]]; then
-                echo "${script}" 
+                echo "${script}"
             else
                 output "${bold}${under}INFO: Currently running script: ${script}${reset}"
             fi
@@ -459,7 +428,7 @@ buildStep() {
 }
 
 # ------------------------------------------------------------------------------
-# Copy extra file tree to ${INSTALLDIR} 
+# Copy extra file tree to ${INSTALLDIR}
 # TODO:  Allow copy per step (04_install_qubes.sh-files)
 #
 # To set file permissions is a PITA since git won't save them and will

--- a/umount_kill.sh
+++ b/umount_kill.sh
@@ -2,12 +2,12 @@
 # vim: set ts=4 sw=4 sts=4 et :
 
 #
-# Written by Jason Mehring (nrgaway@gmail.com) 
-# 
+# Written by Jason Mehring (nrgaway@gmail.com)
+#
 
-# Kills any processes within the mounted location and 
+# Kills any processes within the mounted location and
 # unmounts any mounts active within.
-# 
+#
 # To keep the actual mount mounted, add a '/' to end
 #
 # ${1}: directory to umount
@@ -16,13 +16,13 @@
 # To kill all processes and mounts within 'chroot-jessie' but keep
 # 'chroot-jessie' mounted:
 #
-# ./umount_kill.sh chroot-jessie/ 
+# ./umount_kill.sh chroot-jessie/
 #
 # To kill all processes and mounts within 'chroot-jessie' AND also
 # umount 'chroot-jessie' mount:
 #
 # ./umount_kill.sh chroot-jessie
-# 
+#
 
 . ./functions.sh
 
@@ -44,11 +44,16 @@ mountPoints() {
     echo "$(sudo grep "${mount_point}" /proc/mounts | cut -f2 -d" " | sort -r | grep "^${mount_point}")"
 }
 
-# ${1} = full path to mountpoint; 
+# ${1} = full path to mountpoint;
 # ${2} = if set will not umount; only kill processes in mount
 umount_kill() {
-    # Turn off xtrace; but remember its current setting
-    local xtrace=$(getXtrace) && set +x
+    if [ "${VERBOSE}" -le 2 ]; then
+        # If enabled, turn off xtrace and remember its current setting.
+        if test -o xtrace ; then
+            true "$FUNCNAME: Disabling xtrace, because variable VERBOSE (${VERBOSE}) is lower than or equal 2..."
+            XTRACE_WAS_SET=true
+        fi
+    fi
 
     local mount_point="$(mountPoint "${1}")"
     local kill_only="${2}"
@@ -99,8 +104,10 @@ umount_kill() {
         fi
     done
 
-    # Return xtrace to original state
-    setXtrace "${xtrace}"
+    if [ "$XTRACE_WAS_SET" == "true" ] ; then
+       true "$FUNCNAME: Restoring xtrace..."
+       set -x
+    fi
 }
 
 kill_processes_in_mount() {


### PR DESCRIPTION
https://github.com/QubesOS/qubes-issues/issues/1100
Deprecated functions setVerboseMode, getXtrace, setXtrace and variable XTRACE, because those were broken and their only use case was function umount_kill. Re-implemented disabling xtrace in function umount_kill, if variable VERBOSE is lower than or equal 2.