### PR TITLE
- Fixed 'Qubes Builder: install-templates.sh wants to install the 'same' image multiple times'.

### DIFF
--- a/create_template_list.sh
+++ b/create_template_list.sh
@@ -5,9 +5,50 @@
 # Creates a small script to copy to dom0 to retrieve the generated template rpm's
 #
 
+set -e
+
 template_dir="$(readlink -m ./rpm/install-templates.sh)"
-files=( $(ls rpm/noarch) )
-name=$(xenstore-read name)
+path="$(readlink -m .)/rpm/noarch"
+version="-$(cat ./version)"
+name="$(xenstore-read name)"
+
+files_list_temp="$(echo "rpm/noarch/"*)"
+files_list_temp="$(printf "%s \n" ${files_list_temp[@]})"
+## Newest versions first.
+files_list_temp="$(echo "$files_list_temp" | sort --reverse)"
+
+for file_name in $files_list_temp ; do
+   file_name_without_version="$(echo "${file_name}" | sed -r "s/(${version}).+$//")"
+   template_name="$(basename "$file_name_without_version")"
+   template_list+="$template_name "
+done
+
+template_list="$(printf "%s \n" ${template_list[@]})"
+template_list="$(echo "$template_list" | sort --unique)"
+echo "template_list: $template_list"
+
+declare -A -g remembered
+
+for template_item_from_template_list in $template_list ; do
+   for file_name in $files_list_temp ; do
+      file_name_without_version="$(echo "${file_name}" | sed -r "s/(${version}).+$//")"
+      template_name="$(basename "$file_name_without_version")"
+      file_name_basename="$(basename "$file_name")"
+      if [ ! "$template_item_from_template_list" = "$template_name" ]; then
+         continue
+      fi
+      if [ "${remembered["$template_name"]}" = "true" ]; then
+         files+="#$file_name_basename "
+      else
+         remembered["$template_name"]="true"
+         files+="$file_name_basename "
+      fi
+   done
+done
+
+files="
+$(printf "%s \n" ${files[@]})
+"
 
 # -----------------------------------------------------------------------------
 # Write $vars
@@ -18,12 +59,10 @@ cat << EOF > "${template_dir}"
 # Use the following command in DOM0 to retreive this file:
 # qvm-run --pass-io ${name} 'cat ${template_dir}' > install-templates.sh
 
-files="
-$(printf "%s \n" ${files[@]})
-"
+files="${files}"
 
-path="$(readlink -m .)/rpm/noarch"
-version="-$(cat ./version)"
+path="${path}"
+version="${version}"
 name="${name}"
 EOF
 
@@ -32,24 +71,26 @@ EOF
 # -----------------------------------------------------------------------------
 cat << 'EOF' >> "${template_dir}"
 
-for file in ${files[@]}; do
-    if [ ! -e ${file} ]; then
-        echo "Copying ${file} from ${name} to ${PWD}/${file}..."
-        qvm-run --pass-io ${name} "cat ${path}/${file}" > ${file}
+for file_name in ${files[@]}; do
+    if echo "$file_name" | grep -q '^#' ; then
+       continue
     fi
 
-    sudo yum erase $(echo "${file}" | sed -r "s/(${version}).+$//") && {
-        sudo yum install ${file} && {
-            rm -f ${file}
+    if [ ! -e "${file_name}" ]; then
+        echo "Copying ${file_name} from ${name} to ${PWD}/${file_name}..."
+        qvm-run --pass-io "${name}" "cat ${path}/${file_name}" > "${file_name}"
+    fi
+
+    sudo yum erase $(echo "${file_name}" | sed -r "s/(${version}).+$//") && {
+        sudo yum install "${file_name}" && {
+            rm -f "${file_name}"
         }
     }
 done
 EOF
- 
+
 # -----------------------------------------------------------------------------
 # Display instructions
 # -----------------------------------------------------------------------------
 echo "Use the following command in DOM0 to retreive this file:"
 echo "qvm-run --pass-io ${name} 'cat ${template_dir}' > install-templates.sh"
-
-


### PR DESCRIPTION
- By default, add only newest versions to the list of files to be installed.
- Add older versions commented out by default.
- Do not try to install out commented versions.
- Renamed variable file to file_name ['file' is a unix standard utility].
- Enabled errexit.
- Refactoring, keep write variables part simpler by just writing, not determining variables contents.
- use more quotes

Fixes https://github.com/QubesOS/qubes-issues/issues/1109.