### PR TITLE
function.sh:  Allow multiple template directories to be searched

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -209,6 +209,11 @@ templateDirs() {
         elif [ "${element:0:1}" == "+" -a "${element%:*}" == "+${template_flavor}" ]; then
             eval echo -e "${element#*:}"
             match=1
+        
+        # Generic template directory that matches all flavors, or even no flavors
+        elif [ "${element:0:1}" == "*" ]; then
+            eval echo -e "${element#*:}"
+            match=1
         fi
     done
 

--- a/functions.sh
+++ b/functions.sh
@@ -419,6 +419,7 @@ getFileLocations() {
 buildStep() {
     local filename="$1"
     local suffix="$2"
+    unset build_step_files
 
     info "Locating buildStep files: ${filename##*/} suffix: ${suffix}"
     getFileLocations "build_step_files" "${filename}" "${suffix}"


### PR DESCRIPTION
Return all and run matches instead of only one which allows flavors
like salt to have multiple optional modules like mgmt-salt-dev to
run installation scripts in template subdirectories.
